### PR TITLE
add protocol specification workgroup

### DIFF
--- a/wg-protocol-spec/workgroup.md
+++ b/wg-protocol-spec/workgroup.md
@@ -1,0 +1,18 @@
+# Formal Protocol Specification
+
+The purpose of this workgroup is to coordinate the development, review and acceptance of a formal
+definition document for the bitcoin cash protocol. Initially it is envisaged that the scope will be limited to
+hard consensus rules but later extending into soft rules.
+
+# Communication
+
+* [Telegram Group](#)
+
+# Officers
+
+ * Chairperson: 
+ * Meeting Reporter:
+ * Membership Coordinator:
+
+# Interested Parties
+- Steve Shadders, @shadders, nChain

--- a/workgroup-list.md
+++ b/workgroup-list.md
@@ -43,3 +43,9 @@ certified against.
 
 Defining quality standards against which a node implementation may be
 certified against.
+
+## [Protocol Specification](wg-protocol-spec/workgroup.md)
+
+The purpose of this workgroup is to coordinate the development, review and acceptance of a formal
+definition document for the bitcoin cash protocol. Initially it is envisaged that the scope will be limited to
+hard consensus rules but later extending into soft rules.


### PR DESCRIPTION
adding a workgroup for coordinating the development of a formal specification of the bitcoin cash protocol.