### PR TITLE
Added code-of-conduct, with tweaks to etiquette and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please see [workgroup-list](workgroup-list.md) for information about current wor
 
 # Participating
 
-To participate, join the telegram group listed under each workgroup-specific
+To participate, first read [code-of-conduct](code-of-conduct.md) and [etiquette](etiquette.md). Then, join the telegram group listed under each workgroup-specific
 document, and submit a pull request with some information about yourself in
 the "Interested Parties" section.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+These codes of conduct is the set of rules and expectations for individuals wishing to contribute to the Bitcoin Cash Workgroups.  Repeatedly not adhering to these codes of conduct will not prevent you from contributing code or other work-based merits, but it will prevent you from contributing to discourse.  Individuals breaking these codes of conduct will not be tolerated.
+
+1. Disruptive behaviors that are strictly prohibited:
+   * Non-constructive criticism
+   * Name calling
+   * Speaking over others
+   * Intentional deception, pot-stirring, or otherwise inciting conflict
+   * Otherwise being disruptive to professional discussion
+
+2. Anonymity
+   * You may remain anonymous, or you may use your real name.
+   * A verifiable history is highly recommended regardless of the level of anonymity you choose. Fully anonymous users should have a reasonably long history of positive contribution to other online communities as well.
+   * Anonymous members are encouraged to select names that make their anonymity intent clear. Forging real-sounding names will be considered intentional deception. Participants found to be using a false, but real-sounding name with the intent of deception, will be removed from all future discussions.

--- a/etiquette.md
+++ b/etiquette.md
@@ -1,18 +1,18 @@
 ---
 layout: page
-title: Workgroup Etiquette
+title: Workgroup & Video Meeting Etiquette
 permalink: etiquette.html
 ---
 
 We believe that a common understanding of etiquette enables positive communication, and better cooperation.  This document provides a guideline for our common understanding of workgroup etiquette.  This common understanding makes evaluating more efficient, by helping us to evaluate solutions on a technical, rather than personal, basis.
 
-1. Video meetings take place under a modified Chatham House Rule:
+1. All participants must adhere to the Code of Conduct (see code-of-conduct.md).
+
+2. Video meetings take place under a modified Chatham House Rule:
     
 > “Participants are free to use the information received, but neither the identity nor the affiliation of the speaker(s), nor that of any other participant, may be revealed.”
 
-There will be one exception to this rule: Meeting summaries published to this repository should include a list of the developers in attendance and their respective ecosystem association.  Summaries will have their contents otherwise anonymized.  This provides a forum for discussion that is both private and open, where ideas may be discussed freely without expecting personal reprisals from those not personally engaged in these discussions.
-
-2. Non-constructive criticism, name calling, speaking over others, or otherwise being disruptive to professional discussion is strictly prohibited.
+  There will be one exception to this rule: Meeting summaries published to this repository should include a list of the developers in attendance and their respective ecosystem association.  Summaries will have their contents otherwise anonymized.  This provides a forum for discussion that is both private and open, where ideas may be discussed freely without expecting personal reprisals from those not personally engaged in these discussions.
 
 3. Lurking in video meetings is generally frowned upon. These meetings are intended for productive discussion by ecosystem developers.  Inquisitive parties should look for meeting summaries.  If there are too many non-participant attendees, the chairperson may remove people.
 


### PR DESCRIPTION
I think it's important for us to make it clear that the workgroups are not going to tolerate malicious or even gray actors.  The etiquette made some points about this, but is mostly targeted towards conducting meetings.  These codes of conduct should apply in all circumstances regarding the Bitcoin Cash workgroups.